### PR TITLE
Revert "IA-2279: set secure cookies so latest rocker versions work wi…

### DIFF
--- a/anvil-rstudio-base/CHANGELOG.md
+++ b/anvil-rstudio-base/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.0.5 - 10/27/2020
-
-- Fixed an RStudio cookie setting causing issues with recent rocker versions on Terra
-   - See https://broadworkbench.atlassian.net/browse/IA-2279
-
-Image URL: us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.5
-
 ## 0.0.4 - 07/01/2020
 
 - User installed R and pip packages will now persist between runtimes

--- a/anvil-rstudio-base/README.md
+++ b/anvil-rstudio-base/README.md
@@ -1,6 +1,5 @@
 | Latest Image Release | Docker Image URL | Date Updated | Questions or Feedback |
 | --- | --- | --- | --- |
-| 0.0.5 | us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.5 | 10/27/2020 | Contact the [Interactive Analysis Team](mailto:workbench-interactive-analysis@broadinstitute.org) |
 | 0.0.4 | us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.4 | 07/01/2020 | Contact the [Interactive Analysis Team](mailto:workbench-interactive-analysis@broadinstitute.org) |
 
 # AnVIL RStudio Docker Image

--- a/anvil-rstudio-base/rserver.conf
+++ b/anvil-rstudio-base/rserver.conf
@@ -3,6 +3,5 @@
 
 rsession-which-r=/usr/local/bin/R
 auth-none=1
-auth-cookies-force-secure=1
 www-port=8001
 www-address=127.0.0.1

--- a/anvil-rstudio-bioconductor/CHANGELOG.md
+++ b/anvil-rstudio-bioconductor/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.0.7 - 10/27/2020
-
-- Fixed an RStudio cookie setting causing issues with recent rocker versions on Terra
-   - See https://broadworkbench.atlassian.net/browse/IA-2279
-
-Image URL: us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.7
-
 ## 0.0.6 - 07/01/2020
 
 - User installed R and pip packages will now persist between runtimes

--- a/anvil-rstudio-bioconductor/Dockerfile
+++ b/anvil-rstudio-bioconductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.5
+FROM us.gcr.io/anvil-gcr-public/anvil-rstudio-base:0.0.4
 
 # This is to avoid the error
 # 'debconf: unable to initialize frontend: Dialog'

--- a/anvil-rstudio-bioconductor/README.md
+++ b/anvil-rstudio-bioconductor/README.md
@@ -1,6 +1,5 @@
 | Latest Image Release | Docker Image URL |Date Updated | Questions or Feedback | 
 | --- | --- | --- | --- |
-| 0.0.7 | us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.7 | 10/27/2020 | Contact the [Bioconductor Team](mailto:nitesh.turaga@roswellpark.org) |
 | 0.0.6 | us.gcr.io/anvil-gcr-public/anvil-rstudio-bioconductor:0.0.6 | 07/01/2020 | Contact the [Bioconductor Team](mailto:nitesh.turaga@roswellpark.org) |
 
 # RStudio-Bioconductor Docker Image


### PR DESCRIPTION
…thin iframes"

This reverts commit 9c71ae80c76b06dfee5d822d53fa676613b97921.

I think [this PR](https://github.com/anvilproject/anvil-docker/pull/18) was merged too hastily -- this PR reverts it. I think I have a fix for the issue Leo-side.