### PR TITLE
Increase time out to 3600s

### DIFF
--- a/anvil-rstudio-bioconductor-devel/cloudbuild.yaml
+++ b/anvil-rstudio-bioconductor-devel/cloudbuild.yaml
@@ -8,4 +8,4 @@ steps:
         tag=$(cat ./VERSION)
         docker build -t us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor-devel:$tag .
         docker push us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor-devel:$tag
-timeout: 2400s
+timeout: 3600s


### PR DESCRIPTION
Prevent docker build from timing out on cloud build.